### PR TITLE
RECURRENCE-ID not taken into account by iCalendar.GetOccurences()

### DIFF
--- a/DDay.iCal/iCalendar.cs
+++ b/DDay.iCal/iCalendar.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -759,6 +760,14 @@ namespace DDay.iCal
             {
                 if (recurrable is T)
                     occurrences.AddRange(recurrable.GetOccurrences(startTime, endTime));
+            }
+
+            foreach (var baseRecurringItem in occurrences.Where(o => o.Source is IUniqueComponent)
+                .GroupBy(o => ((IUniqueComponent)o.Source).UID)
+                .SelectMany(@group => @group.Where(o => o.Source.RecurrenceID != null)
+                    .SelectMany(occurrence => @group.Where(o => o.Source.RecurrenceID == null && occurrence.Source.RecurrenceID.Equals(o.Period.StartTime)))))
+            {
+                occurrences.Remove(baseRecurringItem);
             }
 
             occurrences.Sort();


### PR DESCRIPTION
When loading an ics file containing a recurring event and an event with a recurrent id, iCalendar.GetOccurrences() returns occurrences of all events, and doesn't remove occurrence of recurring event overridden by the event with the recurrent id.

ics sample file:

BEGIN:VCALENDAR
PRODID:-//Mozilla.org/NONSGML Mozilla Calendar V1.1//EN
VERSION:2.0
BEGIN:VTIMEZONE
TZID:Europe/Paris
X-LIC-LOCATION:Europe/Paris
BEGIN:DAYLIGHT
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
TZNAME:CEST
DTSTART:19700329T020000
RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3
END:DAYLIGHT
BEGIN:STANDARD
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
TZNAME:CET
DTSTART:19701025T030000
RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
END:STANDARD
END:VTIMEZONE
BEGIN:VEVENT
CREATED:20120418T090312Z
LAST-MODIFIED:20120418T093638Z
DTSTAMP:20120418T093638Z
UID:074aa1e9-3c18-4d23-b40c-1b38ae56af73
SUMMARY:Initial Recurrent Event
RRULE:FREQ=DAILY
EXDATE:20120419T090000Z
DTSTART;TZID=Europe/Paris:20120417T110000
DTEND;TZID=Europe/Paris:20120417T120000
X-MOZ-GENERATION:5
SEQUENCE:2
END:VEVENT
BEGIN:VEVENT
CREATED:20120418T090318Z
LAST-MODIFIED:20120418T090839Z
DTSTAMP:20120418T090839Z
UID:074aa1e9-3c18-4d23-b40c-1b38ae56af73
SUMMARY:Modify Event
RECURRENCE-ID;TZID=Europe/Paris:20120418T110000
DTSTART;TZID=Europe/Paris:20120418T130000
DTEND;TZID=Europe/Paris:20120418T140000
SEQUENCE:1
X-MOZ-GENERATION:5
END:VEVENT
END:VCALENDAR
