### PR TITLE
Exception thrown when we call Dispose on iCalendar

### DIFF
--- a/DDay.iCal/iCalendar.cs
+++ b/DDay.iCal/iCalendar.cs
@@ -812,7 +812,10 @@ namespace DDay.iCal
 
         public void Dispose()
         {
-            Children.Clear();
+            if (!Children.IsReadOnly)
+            {
+                Children.Clear();
+            }
         }
 
         #endregion        


### PR DESCRIPTION
Clear called on a ReadOnlyCollection
